### PR TITLE
feat: incorporate PoK into governance staking

### DIFF
--- a/suiverse-content/sources/articles.move
+++ b/suiverse-content/sources/articles.move
@@ -1911,6 +1911,9 @@ module suiverse_content::articles {
             active_validators: table::new(ctx),
             total_weight: 0,
             total_stake: 0,
+            total_knowledge: 0,
+            knowledge_exchange_rate: 1,
+            current_epoch: 0,
             admin: @0x1,
         };
         
@@ -2054,8 +2057,15 @@ module suiverse_content::articles {
         object::delete(id);
         table::drop(reviews);
         
-        let suiverse_core::governance::ValidatorPool { 
-            id: pool_id, active_validators, total_weight: _, total_stake: _, admin: _ 
+        let suiverse_core::governance::ValidatorPool {
+            id: pool_id,
+            active_validators,
+            total_weight: _,
+            total_stake: _,
+            total_knowledge: _,
+            knowledge_exchange_rate: _,
+            current_epoch: _,
+            admin: _
         } = validator_pool;
         object::delete(pool_id);
         table::drop(active_validators);

--- a/suiverse-content/sources/projects.move
+++ b/suiverse-content/sources/projects.move
@@ -1458,6 +1458,9 @@ module suiverse_content::projects {
             active_validators: table::new(ctx),
             total_weight: 0,
             total_stake: 0,
+            total_knowledge: 0,
+            knowledge_exchange_rate: 1,
+            current_epoch: 0,
             admin: TEST_ADMIN,
         };
         
@@ -1577,6 +1580,9 @@ module suiverse_content::projects {
             active_validators: table::new(ctx),
             total_weight: 0,
             total_stake: 0,
+            total_knowledge: 0,
+            knowledge_exchange_rate: 1,
+            current_epoch: 0,
             admin: TEST_ADMIN,
         };
         
@@ -1688,6 +1694,9 @@ module suiverse_content::projects {
             active_validators: table::new(ctx),
             total_weight: 0,
             total_stake: 0,
+            total_knowledge: 0,
+            knowledge_exchange_rate: 1,
+            current_epoch: 0,
             admin: TEST_ADMIN,
         };
         


### PR DESCRIPTION
## Summary
- track validator knowledge points and dynamic exchange rate per epoch
- use PoK-adjusted voting power when registering, staking and updating validators
- update test scaffolding for expanded `ValidatorPool`

## Testing
- `sui move build` *(fails: command not found)*
- `apt-get install -y sui` *(fails: unable to locate package)*
- `cargo install --locked --git https://github.com/move-language/move move-cli` *(fails: build interrupted)*


------
https://chatgpt.com/codex/tasks/task_b_68b148d2546883308ad974d34847a724